### PR TITLE
Пофиксил накопившиеся недочеты за 2020.07.26

### DIFF
--- a/app/Http/Controllers/Api/TransactionController.php
+++ b/app/Http/Controllers/Api/TransactionController.php
@@ -44,7 +44,7 @@ class TransactionController extends Controller
             ->when($dataTo, function ($query) use ($dataTo) {
                 return $query->where('date', '<=', $dataTo);
             })
-            ->orderBy('date');
+            ->orderByDesc('date');
 
         return new TransactionCollection($query->paginate(10));
     }

--- a/app/Http/Requests/TagFormRequest.php
+++ b/app/Http/Requests/TagFormRequest.php
@@ -29,9 +29,34 @@ class TagFormRequest extends FormRequest
             'name' => [
                 'required',
                 'max:45',
-                Rule::unique('tags')->ignore($this->route('tag'), 'id')->where('user_id', Auth::id()),
+                Rule::unique('tags')
+                    ->ignore($this->route('tag'), 'id')
+                    ->where('user_id', Auth::id())
+                    ->where('expense_id', $this->get('expense_id')),
             ],
             'expense_id' => 'required|int',
+        ];
+    }
+
+    /**
+     * Задаем сообщения об ошибке для заданных полей.
+     * @return array|string[]
+     */
+    public function messages()
+    {
+        return [
+            'name.unique' => ':attribute с таким именем уже существует.'
+        ];
+    }
+
+    /**
+     * Определяем названия заданных атрибутов.
+     * @return array|string[]
+     */
+    public function  attributes()
+    {
+        return [
+            'name' => 'Подкатегория'
         ];
     }
 }

--- a/database/migrations/2020_07_27_101945_increased_length_field_amount_in_tables_points.php
+++ b/database/migrations/2020_07_27_101945_increased_length_field_amount_in_tables_points.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class IncreasedLengthFieldAmountInTablesPoints extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('incomes', function (Blueprint $table) {
+            $table->decimal('amount', 14, 2)->change();
+        });
+        Schema::table('wallets', function (Blueprint $table) {
+            $table->decimal('amount', 14, 2)->change();
+        });
+        Schema::table('expenses', function (Blueprint $table) {
+            $table->decimal('amount', 14, 2)->change();
+        });
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->decimal('amount', 14, 2)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('incomes', function (Blueprint $table) {
+            $table->decimal('amount', 10, 2)->change();
+        });
+        Schema::table('wallets', function (Blueprint $table) {
+            $table->decimal('amount', 10, 2)->change();
+        });
+        Schema::table('expenses', function (Blueprint $table) {
+            $table->decimal('amount', 10, 2)->change();
+        });
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->decimal('amount', 10, 2)->change();
+        });
+    }
+}


### PR DESCRIPTION
1. Для Тегов валидируется названия на уникальность только в рамках текующей категории.
2. При выводе ошибок в валидации тегов на уникальность отправляем собственное сообщение.
3. Увеличена длина поля amount с 10.2 до 14.2 в таблицах incomes, wallets, expenses,transaction.
4. Транзакции теперь отдаются в обратном порядке.