### PR TITLE
Feed Fix: ошибка проверки типа у объекта transactions (frontend)

### DIFF
--- a/resources/js/components/feed/Feed.vue
+++ b/resources/js/components/feed/Feed.vue
@@ -37,12 +37,7 @@
 
     export default {
         props: {
-            transactions: {
-                type: Object,
-                default() {
-                    return null;
-                }
-            },
+            transactions: null,
             editable: {
                 type: Boolean,
                 default() {

--- a/resources/js/store/modules/transactions.js
+++ b/resources/js/store/modules/transactions.js
@@ -76,7 +76,7 @@ export default {
         },
     },
     state: {
-        transactions: {},
+        transactions: null,
         transactionsByPoint: null,
         errorStatus: false,
         errorInfo: 'Не предопределенное сообщение об ошибке ...',


### PR DESCRIPTION
В связи с тем, что при осутствии транзакций за запрошенный период в ответе приходит пустой массив, несмотря на продолжение работы функционала, в консоль выводилось сообщение о том, что ожидался объект, как и случае ответа присутствием транзакций: `Invalid prop: type check failed for prop "transactions". Expected Object, got Array`