### PR TITLE
Report, tags: список сумм по тегам за выбранный период

### DIFF
--- a/app/Http/Controllers/Api/ReportController.php
+++ b/app/Http/Controllers/Api/ReportController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\ReportSumByIncomesCollection;
 use App\Http\Resources\ReportSumByExpensesCollection;
+use App\Http\Resources\ReportSumByTagsCollection;
 use App\Models\Transaction;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -34,14 +35,14 @@ class ReportController extends Controller
         $query->selectRaw('transactions.income_id, sum(transactions.amount) as amount, i.name')
             ->Join('incomes as i', 'transactions.income_id', '=', 'i.id')
             ->where('transactions.user_id', Auth::id())
-            ->whereNotNull('income_id')
+            ->whereNotNull('transactions.income_id')
             ->when($dateFrom, function ($query) use ($dateFrom) {
-                return $query->where('date', '>=', $dateFrom);
+                return $query->where('transactions.date', '>=', $dateFrom);
             })
             ->when($dateTo, function ($query) use ($dateTo) {
-                return $query->where('date', '<=', $dateTo);
+                return $query->where('transactions.date', '<=', $dateTo);
             })
-            ->groupBy(['income_id']);
+            ->groupBy(['transactions.income_id']);
 
         return new ReportSumByIncomesCollection($query->get());
     }
@@ -63,15 +64,51 @@ class ReportController extends Controller
         $query->selectRaw('transactions.expense_id, sum(transactions.amount) as amount, e.name')
             ->Join('expenses as e', 'transactions.expense_id', '=', 'e.id')
             ->where('transactions.user_id', Auth::id())
-            ->whereNotNull('expense_id')
+            ->whereNotNull('transactions.expense_id')
             ->when($dateFrom, function ($query) use ($dateFrom) {
-                return $query->where('date', '>=', $dateFrom);
+                return $query->where('transactions.date', '>=', $dateFrom);
             })
             ->when($dateTo, function ($query) use ($dateTo) {
-                return $query->where('date', '<=', $dateTo);
+                return $query->where('transactions.date', '<=', $dateTo);
             })
-            ->groupBy(['expense_id']);
+            ->groupBy(['transactions.expense_id']);
 
         return new ReportSumByExpensesCollection($query->get());
+    }
+
+    /**
+     * @param Request $request
+     * @return ReportSumByTagsCollection
+     * @throws ValidationException
+     */
+    public function sumByTags(Request $request)
+    {
+        // Выполняем валидацию данных из запроса.
+        $this->validate($request, [
+            'expense_id' => 'required|int',
+            'date_from' => 'nullable|date',
+            'date_to' => 'nullable|date|after_or_equal:date_from',
+        ]);
+
+        // Получаем данные из запроса.
+        $expense_id = request('expense_id');
+        $dateFrom = request('date_from');
+        $dateTo = request('date_to');
+
+        $query = Transaction::query();
+
+        $query->selectRaw('transactions.tag_id, sum(transactions.amount) as amount, t.name')
+            ->Join('tags as t', 'transactions.tag_id', '=', 't.id')
+            ->where('transactions.user_id', Auth::id())
+            ->where('t.expense_id', $expense_id)
+            ->when($dateFrom, function ($query) use ($dateFrom) {
+                return $query->where('transactions.date', '>=', $dateFrom);
+            })
+            ->when($dateTo, function ($query) use ($dateTo) {
+                return $query->where('transactions.date', '<=', $dateTo);
+            })
+            ->groupBy(['transactions.tag_id']);
+
+        return new ReportSumByTagsCollection($query->get());
     }
 }

--- a/app/Http/Resources/ReportSumByTagsCollection.php
+++ b/app/Http/Resources/ReportSumByTagsCollection.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class ReportSumByTagsCollection extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'data' => $this->collection->keyBy('tag_id')
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -47,7 +47,9 @@ Route::middleware('auth:api')->group(function () {
         // ОТЧЕТЫ ------------------------------------------------------------------
         // Возвращаем суммы по каждому элементу доходов.
         Route::get('report/sum-incomes', 'ReportController@sumByIncomes');
-        //Возвращаем суммы по каждому элементу расходов.
+        // Возвращаем суммы по каждому элементу расходов.
         Route::get('report/sum-expenses', 'ReportController@sumByExpenses');
+        // Возвращаем суммы по каждому элементу подкатегории расходов.
+        Route::get('report/sum-tags', 'ReportController@sumByTags');
     });
 });


### PR DESCRIPTION
Реализовано api для получения данных о суммах транзакций по каждому элементу подкатегорий расхода за выбранный период.
Фронт запрашивает данные по (get) api/report/sum-tags?expense_id={expense_id}&date_from={date}&date_to={date}. Любое из передаваемых значений (date_from или date_to) может быть пустым или отсутствовать, expense_id обязательно для заполнения.

Так же изменен синтаксис запросов для совместимости в методах sumByTags, sumByIncomes, sumByExpenses