### PR TITLE
Report: Реализовано api для получения сумм сгруппированных по месяцам.

### DIFF
--- a/app/Helpers/ReportHelpers.php
+++ b/app/Helpers/ReportHelpers.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Helpers;
+
+use App\Models\Transaction;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Class ReportHelpers
+ * @package App\Helpers
+ */
+class ReportHelpers
+{
+    /**
+     * Метод получает на вход начальную и конечную дату периода, и возвращает массив в котором заданный период
+     * разбит по месяцам и передается дата первого и последнего дня месяца: startDayOfMonth и endDayOfMonth.
+     *
+     * @param string $date_from
+     * @param string $date_to
+     * @return mixed
+     */
+    public static function getArrMonthsForPeriod(string $date_from, string $date_to)
+    {
+        $dateFrom = Carbon::parse($date_from);
+        $dateTo = Carbon::parse($date_to);
+
+        $startDayOfMonth = $dateFrom->startOfMonth()->toDateString();
+        $endDayOfMonth = $dateFrom->endOfMonth()->toDateString();
+
+        $dateArr[] = [
+            'start' => $startDayOfMonth,
+            'end' => $endDayOfMonth,
+        ];
+
+        $nextMonth = $dateFrom;
+
+        while ($nextMonth <= $dateTo) {
+            $nextMonth = $nextMonth->addMonthNoOverflow();
+
+            $startDayOfMonth = $nextMonth->startOfMonth()->toDateString();
+            $endDayOfMonth = $nextMonth->endOfMonth()->toDateString();
+
+            $dateArr[] = [
+                'start' => $startDayOfMonth,
+                'end' => $endDayOfMonth,
+            ];
+        }
+
+        return $dateArr;
+    }
+
+    /**
+     * Метод создает массив из сгруппированных по месяцам элементов, в каждом элементе содержится ID поинта (income_id),
+     * общая сумма транзакций за данный месяц (amount) и название поинта (name).
+     *
+     * @param array $dateArr
+     * @param string $point_table
+     * @param string $point_id
+     * @return array
+     */
+    public static function getArrWithSumPointsByDate(array $dateArr, string $point_table, string $point_id)
+    {
+        $result = [];
+
+        foreach ($dateArr as $item) {
+            // Даты начала и конца периода.
+            $dateFrom = $item['start'];
+            $dateTo = $item['end'];
+
+            $query = Transaction::query();
+
+            $query->selectRaw('transactions.' . $point_id . ', sum(transactions.amount) as amount, p.name')
+                ->join('' . $point_table . ' as p', 'transactions.' . $point_id . '', '=', 'p.id')
+                ->where('transactions.user_id', Auth::id())
+                ->whereNotNull('transactions.' . $point_id . '')
+                ->when($dateFrom, function ($query) use ($dateFrom) {
+                    return $query->where('transactions.date', '>=', $dateFrom);
+                })
+                ->when($dateTo, function ($query) use ($dateTo) {
+                    return $query->where('transactions.date', '<=', $dateTo);
+                })
+                ->groupBy(['transactions.' . $point_id . '', 'p.name']);
+
+            $result[$dateFrom] = $query->get();
+        }
+
+        return $result;
+    }
+}

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -4,7 +4,6 @@ namespace App\Models;
 
 use App\Http\Requests\TransactionFormRequest;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Mockery\Exception;
@@ -29,6 +28,17 @@ class Transaction extends Model
     const TYPE_INCOME = 1;
     const TYPE_TRANSFER = 2;
     const TYPE_EXPENSE = 3;
+
+    /**
+     * Задаем какие атрибуты будут преобразованы в Даты.
+     *
+     * @var array
+     */
+    protected $dates = [
+        'created_at',
+        'updated_at',
+        'date',
+    ];
 
     /**
      * Метод заполняет модель значениями поступившими из запроса в соответствии с типом операции.

--- a/routes/api.php
+++ b/routes/api.php
@@ -51,5 +51,7 @@ Route::middleware('auth:api')->group(function () {
         Route::get('report/sum-expenses', 'ReportController@sumByExpenses');
         // Возвращаем суммы по каждому элементу подкатегории расходов.
         Route::get('report/sum-tags', 'ReportController@sumByTags');
+        // Возвращаем сумму по каждому элементу сгруппированные по месяцам.
+        Route::get('report/sum-points-by-months', 'ReportController@sumByPointsByMonths');
     });
 });


### PR DESCRIPTION
Реализовано api для получения данных о суммах транзакций по каждому элементу расходов или доходов за выбранный период сгруппированных по месяцам.

Фронт запрашивает данные по (get) api/report/sum-points-by-months?date_from={date}&date_to={date}&type={type}. Все поля обязательны для заполнения.

Так же изменена логика вывода тегов, теперь сумма по тегам считается не только в существующих тегах расходов, но и тех траyзакций, которые не имеют тегов, для них tag_id = null.