### PR TITLE
Transaction: Добавлена возможность выводить транзакции по кошелькам

### DIFF
--- a/app/Http/Controllers/Api/TransactionController.php
+++ b/app/Http/Controllers/Api/TransactionController.php
@@ -7,7 +7,6 @@ use App\Http\Requests\TransactionFormRequest;
 use App\Http\Resources\Transaction as TransactionResource;
 use App\Http\Resources\TransactionCollection;
 use App\Models\Transaction;
-use http\Env\Response;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -31,6 +30,7 @@ class TransactionController extends Controller
             'page' => 'nullable|int',
             'income_id' => 'nullable|int',
             'expense_id' => 'nullable|int',
+            'wallet_id' => 'nullable|int',
             'type' => 'nullable|int',
         ]);
 
@@ -39,6 +39,7 @@ class TransactionController extends Controller
         $dateTo = request('date_to');
         $incomeID = request('income_id');
         $expenseID = request('expense_id');
+        $walletID = request('wallet_id');
         $type = request('type');
 
         $query = Transaction::query();
@@ -56,6 +57,10 @@ class TransactionController extends Controller
             })
             ->when($expenseID, function ($query) use ($expenseID) {
                 return $query->where('expense_id', '=', $expenseID);
+            })
+            ->when($walletID, function ($query) use ($walletID) {
+                return $query->where('wallet_id_from', '=', $walletID)
+                    ->orWhere('wallet_id_to', '=', $walletID);
             })
             ->when($type, function ($query) use ($type) {
                 return $query->where('type', '=', $type);

--- a/app/Http/Resources/TransactionCollection.php
+++ b/app/Http/Resources/TransactionCollection.php
@@ -22,6 +22,7 @@ class TransactionCollection extends ResourceCollection
         // Получаем данные из запроса.
         $incomeID = request('income_id');
         $expenseID = request('expense_id');
+        $walletID = request('wallet_id');
         $type = request('type');
 
         // Получаем массив транзакций для каждого элемента входного массива пагинации.
@@ -31,6 +32,10 @@ class TransactionCollection extends ResourceCollection
             })
             ->when($expenseID, function ($query) use ($expenseID) {
                 return $query->where('expense_id', '=', $expenseID);
+            })
+            ->when($walletID, function ($query) use ($walletID) {
+                return $query->where('wallet_id_from', '=', $walletID)
+                    ->orWhere('wallet_id_to', '=', $walletID);
             })
             ->when($type, function ($query) use ($type) {
                 return $query->where('type', '=', $type);


### PR DESCRIPTION
Добавлена возможность выводить транзакции по кошелькам.

(get) /api/transactions?page={page}&date_from={date}&date_to={date}&income_id={income_id}&expense_id={expense_id}&type={type}&wallet_id={wallet_id}

Для примера:
/api/transactions?page=2&date_from=2020-07-03&date_to=2020-07-08&wallet_id=2

Любое из передаваемых значений может быть пустым или отсутствовать, например:
/api/transactions?date_from=&date_to=2020-07-08&wallet_id=2 (покажет все транзакции совершенные до даты 2020-07-08 включительно с выборкой по wallet_id=2, и так как page не указан, вернет данные для первой страницы.